### PR TITLE
very minor -- not even worth claiming an authorship ;-): spelling + trailing spaces

### DIFF
--- a/gitwash/development_workflow.rst
+++ b/gitwash/development_workflow.rst
@@ -334,7 +334,7 @@ Rewriting commit history
 
    Do this only for your own feature branches.
 
-There's an embarassing typo in a commit you made? Or perhaps the you
+There's an embarrassing typo in a commit you made? Or perhaps the you
 made several false starts you would like the posterity not to see.
 
 This can be done via *interactive rebasing*.

--- a/gitwash/git_resources.rst
+++ b/gitwash/git_resources.rst
@@ -9,9 +9,9 @@ Tutorials and summaries
 
 * `github help`_ has an excellent series of how-to guides.
 * `learn.github`_ has an excellent series of tutorials
-* The `pro git book`_ is a good in-depth book on git. 
+* The `pro git book`_ is a good in-depth book on git.
 * A `git cheat sheet`_ is a page giving summaries of common commands.
-* The `git user manual`_ 
+* The `git user manual`_
 * The `git tutorial`_
 * The `git community book`_
 * `git ready`_ |emdash| a nice series of tutorials


### PR DESCRIPTION
my original wonder was about non-uniform use of prefixes, such as ENH, BF, ... in the examples and their separation from the comment itself  e.g.

```
$> git grep ENH   
gitwash/development_workflow.rst:     git commit -am 'ENH - much better code'
gitwash/development_workflow.rst:     721fc64 ENH: Sophisticated feature

should they be better suggested explicitly (nowhere mentioned) and uniformized, e.g. suggesting to use something like 

[(ENH|BF|...) - ][subproj:] msg

as the template, e.g.

ENH - doc: extended examples

?  just an idea
```
